### PR TITLE
Add dashboard rebuild to post install

### DIFF
--- a/Formula/den.rb.template
+++ b/Formula/den.rb.template
@@ -7,8 +7,6 @@ class Den < Formula
   sha256 "${HASH}"
   head "https://github.com/swiftotter/den.git", :branch => "main"
 
-  conflicts_with "davidalger/warden/warden", because: "Den is a replacement fork of Warden"
-
   # Check if Docker Desktop is installed; otherwise, install it via brew
   depends_on cask: "docker" unless File.exists?("/Applications/Docker.app")
 
@@ -21,7 +19,8 @@ class Den < Formula
     ENV["PATH"] += ":/usr/local/bin" if OS.mac? || OS.linux?
 
     # Specify necessary environment variables
-    ENV["WARDEN_HOME_DIR"] = prefix
+    ENV["WARDEN_DIR"] = prefix
+    ENV["WARDEN_HOME_DIR"] = Dir.home
     ENV["WARDEN_SERVICE_DIR"] = prefix
 
     # Future proof environment variable names
@@ -30,6 +29,7 @@ class Den < Formula
 
     Pathname(prefix/"docker").cd do
       den_version = File.read(prefix/"version").strip()
+      den_version = "testing-bap14"
       system "docker",
             "compose",
             "-p", "den",
@@ -41,7 +41,8 @@ class Den < Formula
             "compose",
             "--project-directory", prefix,
             "-p", "den",
-            "up", "-d"
+            "-f", prefix/"docker/docker-compose.yml",
+            "up", "-d", "dashboard"
     end
   end
 
@@ -54,7 +55,7 @@ class Den < Formula
       To start warden simply run:
         den svc up
       
-      This command will automatically run "den install" to setup a trusted
+      This command will automatically run an installation if necessary to setup a trusted
       local root certificate and sign an SSL certificate for use by services
       managed by warden via the "warden sign-certificate warden.test" command.
       To print a complete list of available commands simply run "den" without

--- a/Formula/den.rb.template
+++ b/Formula/den.rb.template
@@ -29,7 +29,6 @@ class Den < Formula
 
     Pathname(prefix/"docker").cd do
       den_version = File.read(prefix/"version").strip()
-      den_version = "testing-bap14"
       system "docker",
             "compose",
             "-p", "den",

--- a/Formula/den.rb.template
+++ b/Formula/den.rb.template
@@ -37,6 +37,11 @@ class Den < Formula
             "--no-cache",
             "--build-arg", "DEN_VERSION=#{den_version}",
             "dashboard"
+      system "docker",
+            "compose",
+            "--project-directory", prefix,
+            "-p", "den",
+            "up", "-d"
     end
   end
 
@@ -49,7 +54,7 @@ class Den < Formula
       To start warden simply run:
         den svc up
       
-      This command will automatically run an installation if necessary to setup a trusted
+      This command will automatically run "den install" to setup a trusted
       local root certificate and sign an SSL certificate for use by services
       managed by warden via the "warden sign-certificate warden.test" command.
       To print a complete list of available commands simply run "den" without

--- a/Formula/den.rb.template
+++ b/Formula/den.rb.template
@@ -1,22 +1,55 @@
 class Den < Formula
   desc "Den is a CLI utility for working with docker-compose environments"
+  homepage "https://swiftotter.github.io/den"
+  license "MIT"
   version "${VERSION}"
   url "https://github.com/swiftotter/den/archive/${VERSION}.tar.gz"
   sha256 "${HASH}"
   head "https://github.com/swiftotter/den.git", :branch => "main"
 
+  conflicts_with "davidalger/warden/warden", because: "Den is a replacement fork of Warden"
+
+  # Check if Docker Desktop is installed; otherwise, install it via brew
+  depends_on cask: "docker" unless File.exists?("/Applications/Docker.app")
+
   def install
     prefix.install Dir["*"]
+  end
+
+  def post_install
+    # This is required so docker is found if it's not installed via brew
+    ENV["PATH"] += ":/usr/local/bin" if OS.mac? || OS.linux?
+
+    # Specify necessary environment variables
+    ENV["WARDEN_HOME_DIR"] = prefix
+    ENV["WARDEN_SERVICE_DIR"] = prefix
+
+    # Future proof environment variable names
+    ENV["DEN_HOME_DIR"] = prefix
+    ENV["DEN_SERVICE_DIR"] = prefix
+
+    Pathname(prefix/"docker").cd do
+      den_version = File.read(prefix/"version").strip()
+      system "docker",
+            "compose",
+            "-p", "den",
+            "build",
+            "--no-cache",
+            "--build-arg", "DEN_VERSION=#{den_version}",
+            "dashboard"
+    end
   end
 
   def caveats
     <<~EOS
       Den manages a set of global services on the docker host machine. You
-      will need to have Docker installed and docker-compose available in your
+      will need to have Docker installed and Docker Compose (>= 2.2.3) available in your
       local $PATH configuration prior to starting Den.
+
       To start warden simply run:
         den svc up
-      This command will automatically run "den install" to setup a trusted
+      
+      This command will automatically run an installation if necessary to setup a trusted
       local root certificate and sign an SSL certificate for use by services
       managed by warden via the "warden sign-certificate warden.test" command.
       To print a complete list of available commands simply run "den" without
@@ -24,3 +57,4 @@ class Den < Formula
     EOS
   end
 end
+

--- a/Formula/den.rb.template
+++ b/Formula/den.rb.template
@@ -55,7 +55,7 @@ class Den < Formula
       To start warden simply run:
         den svc up
       
-      This command will automatically run an installation if necessary to setup a trusted
+      This command will automatically run "den install" to setup a trusted
       local root certificate and sign an SSL certificate for use by services
       managed by warden via the "warden sign-certificate warden.test" command.
       To print a complete list of available commands simply run "den" without


### PR DESCRIPTION
This adds some "required" items for Homebrew Formulae, as well as adds a post install hook that will rebuild the Den Dashboard image to use the current version.

This should be merged together with my other PR in swiftotter/den repo as there are necessary dockerfile and index.html updates that are needed for this to work.