### PR TITLE
Fix dependency check for Docker to actually work

### DIFF
--- a/Formula/den.rb.template
+++ b/Formula/den.rb.template
@@ -1,3 +1,54 @@
+class DockerRequirement < Requirement
+  fatal true
+
+  DOCKER_MIN_VERS = "20.10.16"
+  COMPOSE_MIN_VERS = "2.2.3"
+
+  satisfy(build_env: false) { self.class.has_docker? }
+
+  def message
+    "Docker with Docker Compose >= #{COMPOSE_MIN_VERS} is " \
+    "required for Den. Please install Docker Desktop via brew with 'brew " \
+    "install --cask docker', download it from https://docker.com/ or use " \
+    "your system package manager to install Docker Engine "\
+    ">= #{DOCKER_MIN_VERS}"
+  end
+
+  def self.has_docker?
+    self.docker_installed? &&
+      (
+        self.docker_minimum_version_met? &&
+        self.docker_compose_minimum_version_met?
+      )
+  end
+
+  def self.docker_installed?
+    return File.exists?("/Applications/Docker.app") &&
+      File.exists?("/usr/local/bin/docker") if OS.mac?
+    return File.exists?("/usr/bin/docker") if OS.linux?
+  end
+
+  def self.get_docker_exec
+    return "/usr/local/bin/docker" if OS.mac?
+    return "/usr/bin/docker" if OS.linux?
+  end
+
+  def self.docker_minimum_version_met?
+    docker_exec = self.get_docker_exec
+    current_vers, status =\
+      Open3.capture2("#{docker_exec} version --format '{{.Server.Version}}'")
+    return false if !status.success?
+    return Gem::Version.new(current_vers) >= Gem::Version.new(DOCKER_MIN_VERS)
+  end
+
+  def self.docker_compose_minimum_version_met?
+    docker_exec = self.get_docker_exec
+    current_vers, status = Open3.capture2("#{docker_exec} compose version --short")
+    return false if !status.success?
+    return Gem::Version.new(current_vers) >= Gem::Version.new(COMPOSE_MIN_VERS)
+  end
+end
+
 class Den < Formula
   desc "Den is a CLI utility for working with docker-compose environments"
   homepage "https://swiftotter.github.io/den"
@@ -7,8 +58,7 @@ class Den < Formula
   sha256 "${HASH}"
   head "https://github.com/swiftotter/den.git", :branch => "main"
 
-  # Check if Docker Desktop is installed; otherwise, install it via brew
-  depends_on cask: "docker" unless File.exists?("/Applications/Docker.app")
+  depends_on DockerRequirement
 
   def install
     prefix.install Dir["*"]
@@ -48,8 +98,8 @@ class Den < Formula
   def caveats
     <<~EOS
       Den manages a set of global services on the docker host machine. You
-      will need to have Docker installed and Docker Compose (>= 2.2.3) available in your
-      local $PATH configuration prior to starting Den.
+      will need to have Docker running and Docker Compose (>= 2.2.3) available in 
+      your local $PATH configuration prior to starting Den.
 
       To start warden simply run:
         den svc up
@@ -62,4 +112,3 @@ class Den < Formula
     EOS
   end
 end
-


### PR DESCRIPTION
This will fix https://github.com/swiftotter/homebrew-den/issues/3 

 - Dependency requirement set to use custom object
 - Custom object will validate the following
   - Docker >= 20.10.16 installed
   - Docker Compose >= 2.2.3 installed
 - Adjusted caveat to be clearer
 - Removed version from caveat since it's handled in dependency requirement