### PR TITLE
Add Dependencies to Homebrew

### DIFF
--- a/Formula/den.rb.template
+++ b/Formula/den.rb.template
@@ -66,6 +66,8 @@ class Den < Formula
   head "https://github.com/swiftotter/den.git", :branch => "main"
 
   depends_on DockerRequirement
+  depends_on "gettext"
+  depends_on "pv" => :recommended
 
   def install
     prefix.install Dir["*"]


### PR DESCRIPTION
* gettext required for `envsubst` commands in env-init
* pv recommended (installs automatically but a flag can be passed to not install it)