### PR TITLE
Update den.rb

### DIFF
--- a/Formula/den.rb
+++ b/Formula/den.rb
@@ -32,9 +32,9 @@ class DockerRequirement < Requirement
   end
 
   def self.docker_installed?
-    return File.exists?("/Applications/Docker.app") &&
-      File.exists?("/usr/local/bin/docker") if OS.mac?
-    return File.exists?("/usr/bin/docker") if OS.linux?
+    return File.exist?("/Applications/Docker.app") &&
+      File.exist?("/usr/local/bin/docker") if OS.mac?
+    return File.exist?("/usr/bin/docker") if OS.linux?
   end
 
   def self.get_docker_exec


### PR DESCRIPTION
The method File.exists? was deprecated in Ruby 2.1.0 and officially removed in Ruby 3.0. exist singular is backwards compatible.